### PR TITLE
static build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ module: module.tar.gz
 bin/viamrosclimodule: go.mod *.go cmd/module/*.go
 	go build -o bin/viamrosclimodule cmd/module/cmd.go
 
+bin/static/viamrosclimodule: go.mod *.go cmd/module/*.go
+	mkdir -p bin/static
+	go build -tags osusergo,netgo -ldflags="-extldflags=-static -s -w" -o $@ cmd/module/cmd.go
+
 lint:
 	gofmt -s -w .
 

--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,6 @@
 module: module.tar.gz
 
 bin/viamrosclimodule: go.mod *.go cmd/module/*.go
-	go build -o bin/viamrosclimodule cmd/module/cmd.go
-
-bin/static/viamrosclimodule: go.mod *.go cmd/module/*.go
-	mkdir -p bin/static
 	go build -tags osusergo,netgo -ldflags="-extldflags=-static -s -w" -o $@ cmd/module/cmd.go
 
 lint:


### PR DESCRIPTION
## What changed
Add static ldflags to build
## Notes
This warns with:
> /usr/bin/ld: /tmp/go-link-4038652656/000031.o: in function `ma_dlopen':
> /.../gopath/pkg/mod/github.com/gen2brain/malgo@v0.11.21/miniaudio.h:17836: warning: Using 'dlopen' in statically linked applications requires at runtime the shared libraries from the glibc version used for linking

There's a chance this behaves badly at runtime; hopefully only in audio paths. If this solves the main problem, we can debug the audio piece separately.